### PR TITLE
Fix off-by-one error with treeSplitElt[] and treeSplit[].

### DIFF
--- a/gif.h
+++ b/gif.h
@@ -72,8 +72,8 @@ struct GifPalette
     // k-d tree over RGB space, organized in heap fashion
     // i.e. left child of node i is node i*2, right child is node i*2+1
     // nodes 256-511 are implicitly the leaves, containing a color
-    uint8_t treeSplitElt[255];
-    uint8_t treeSplit[255];
+    uint8_t treeSplitElt[256];
+    uint8_t treeSplit[256];
 };
 
 // max, min, and abs functions


### PR DESCRIPTION
According to calculation logic of treeRoot in GifGetClosestPaletteColor(), max treeRoot value may be 255, so sizes of treeSplitElt[] and treeSplit[] in struct GifPalette should be 256, and not 255. Currently there may be an out-of-bounds error when accessing pPal->treeSplitElt[treeRoot] in GifGetClosestPaletteColor() and other places too. Proposed patch fixes this.