### PR TITLE
docs: fix simple typo, palete -> palette

### DIFF
--- a/gif.h
+++ b/gif.h
@@ -425,7 +425,7 @@ void GifDitherImage( const uint8_t* lastFrame, const uint8_t* nextFrame, uint8_t
             int32_t bestDiff = 1000000;
             int32_t bestInd = kGifTransIndex;
 
-            // Search the palete
+            // Search the palette
             GifGetClosestPaletteColor(pPal, rr, gg, bb, &bestInd, &bestDiff, 1);
 
             // Write the result to the temp buffer


### PR DESCRIPTION
There is a small typo in gif.h.

Should read `palette` rather than `palete`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md